### PR TITLE
Try native PECL Yaml parser first if installed

### DIFF
--- a/File/src/MarkdownFile.php
+++ b/File/src/MarkdownFile.php
@@ -139,10 +139,10 @@ class MarkdownFile extends File
 
             // Try native PECL Yaml PHP extension first if available, otherwise fall back to symfony\Yaml parser
             if (function_exists('yaml_parse')) {
-                $data = preg_replace("/ (@[\w\.\-]*)/", " '\${1}'", $content['frontmatter']); // Fix illegal @ start character issue
-                $data = @yaml_parse("---\n" . $data . "\n...");
-                if ($data)
-                    $content['header'] = $data;
+                $data = $content['frontmatter'];
+                if (strpos($data, ' @'))
+                    $data = preg_replace("/ (@[\w\.\-]*)/", " '\${1}'", $data); // Fix illegal @ start character issue
+                $content['header'] = @yaml_parse("---\n" . $data . "\n...");
                 // else continue with symfony\Yaml parser if there have been parse errors...
             }
             if (!$content['header'])

--- a/File/src/YamlFile.php
+++ b/File/src/YamlFile.php
@@ -61,6 +61,15 @@ class YamlFile extends File
      */
     protected function decode($var)
     {
+        // Try native PECL Yaml PHP extension first if available, otherwise fall back to symfony\Yaml parser
+        if (function_exists('yaml_parse')) {
+            $data = preg_replace("/ (@[\w\.\-]*)/", " '\${1}'", $var); // Fix illegal @ start character issue
+            $data = @yaml_parse("---\n" . $data . "\n...");
+            if ($data)
+                return $data;
+            // else continue with symfony\Yaml parser if there have been parse errors...
+        }
+
         return (array) YamlParser::parse($var);
     }
 }

--- a/File/src/YamlFile.php
+++ b/File/src/YamlFile.php
@@ -63,7 +63,10 @@ class YamlFile extends File
     {
         // Try native PECL Yaml PHP extension first if available, otherwise fall back to symfony\Yaml parser
         if (function_exists('yaml_parse')) {
-            $data = preg_replace("/ (@[\w\.\-]*)/", " '\${1}'", $var); // Fix illegal @ start character issue
+            if (strpos($var, ' @'))
+                $data = preg_replace("/ (@[\w\.\-]*)/", " '\${1}'", $var); // Fix illegal @ start character issue
+            else
+                $data = $var;
             $data = @yaml_parse("---\n" . $data . "\n...");
             if ($data)
                 return $data;


### PR DESCRIPTION
Try native PHP Yaml parser first and then fallback to symfony\Yaml if not available or it has parsing issues.

Refer to https://github.com/getgrav/grav/issues/343

In your php.ini file add those lines:

    ; YAML PECL extension
    extension=php_yaml.dll
