### PR TITLE
Add a UniformResourceLocator::resetScheme() method.

### DIFF
--- a/ResourceLocator/src/UniformResourceLocator.php
+++ b/ResourceLocator/src/UniformResourceLocator.php
@@ -72,6 +72,21 @@ class UniformResourceLocator implements ResourceLocatorInterface
     }
 
     /**
+     * Reset a locator scheme
+     *
+     * @param string $scheme The scheme to reset
+     * 
+     * @return $this
+     */
+    public function resetScheme($scheme)
+    {
+        $this->schemes[$scheme] = [];
+        $this->cache = [];
+        
+        return $this;
+    }
+
+    /**
      * Add new paths to the scheme.
      *
      * @param string $scheme


### PR DESCRIPTION
Resets the scheme passed as parameter. Useful when changing scheme paths at runtime.