### PR TITLE
Fix breaking YAML files which start with three dashes

### DIFF
--- a/File/src/YamlFile.php
+++ b/File/src/YamlFile.php
@@ -75,7 +75,7 @@ class YamlFile extends File
             // Safely decode YAML.
             $saved = @ini_get('yaml.decode_php');
             @ini_set('yaml.decode_php', 0);
-            $data = @yaml_parse("---\n" . $data . "\n...");
+            $data = @yaml_parse($data);
             @ini_set('yaml.decode_php', $saved);
         }
 


### PR DESCRIPTION
Solves issue with language files exported from Crowdin containing three dashes on top