### PR TITLE
Remove BOM in Markdown files, if it exists

### DIFF
--- a/File/src/MarkdownFile.php
+++ b/File/src/MarkdownFile.php
@@ -130,6 +130,9 @@ class MarkdownFile extends File
 
         $frontmatter_regex = "/^---\n(.+?)\n---\n{0,}(.*)$/uis";
 
+        // Remove UTF-8 BOM if it exists.
+        $var = ltrim($var, "\xef\xbb\xbf");
+
         // Normalize line endings to Unix style.
         $var = preg_replace("/(\r\n|\r)/", "\n", $var);
 


### PR DESCRIPTION
If a Markdown is saved with the UTF-8 BOM (using Windows' Notepad for instance), Frontmatter isn't detected.

This PR removes the BOM, prior to the Frontmatter detection.