### PR TITLE
support for `replace-name@`

### DIFF
--- a/Blueprints/src/BlueprintForm.php
+++ b/Blueprints/src/BlueprintForm.php
@@ -341,7 +341,17 @@ abstract class BlueprintForm implements \ArrayAccess, ExportInterface
                         case 'replace':
                             if (!$property) {
                                 $bref = ['unset@' => true];
-                            } else {
+                            }
+                            // replace-name@ was used to override the name of a field previously imported
+                            elseif ($property == 'name' && isset($head['name'])) {
+                                // in the main array, copy field reference under the new name ($header['name'])
+                                $a[$head['name']] = &$bref;
+                                // unset the previous index
+                                unset($a[$bref['name']]);
+                                // (internal "name" is also replaced)
+                                $bref['name'] = $head['name'];
+                            }
+                            else {
                                 unset($bref[$property]);
                             }
                             continue 2;


### PR DESCRIPTION
When creating a form blueprint, the **name matters**. For example `header.some.thing`.
That makes impossible to reuse named fields.

Let's say a plugin defines such a `foobar` field:
```yaml
# blueprints.yaml
form:
  validation: strict
  fields:
   foobar:
      type: select
      label: Default value if not overriden per-page
      data-options@: '\Grav\Plugin\MyPlugin::foobar'
```

But such value can be override on a page basis. The best is to reuse already defined blueprint:
```yaml
# blueprints/modular/form.yaml
form:
  fields:
    # importing blueprint admin fields for per-page override
    import@:
      type: blueprints.yaml:form/fields # <-- this syntax is horribly difficult to deduce and undocumented
      context: plugins://myplugin

    # and override
    enabled: { unset@: true } # sure, this is not needed

    # `foobar` is not ok, in this context we must use `header.form.foobar`
    foobar:
      replace-name@: true
      name: header.form.foobar
```

See also: #23