### PR TITLE
Fix trim(null) deprecation

### DIFF
--- a/Compat/src/Yaml/Inline.php
+++ b/Compat/src/Yaml/Inline.php
@@ -45,7 +45,7 @@ class Inline
         self::$objectSupport = $objectSupport;
         self::$objectForMap = $objectForMap;
 
-        $value = trim($value);
+        $value = trim($value ?? '');
 
         if ('' === $value) {
             return '';


### PR DESCRIPTION
Quick fix so it will work with PHP 8+
This is the cause of https://github.com/gantry/gantry5/issues/3130